### PR TITLE
favicon.ico使用绝对路径

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="{{ site.description }}">
     <meta name="keyword"  content="{{ site.keyword }}">
-    <link rel="shortcut icon" href="img/favicon.ico">
+    <link rel="shortcut icon" href="/img/favicon.ico">
 
     <title>{% if page.title %}{{ page.title }} - {{ site.SEOTitle }}{% else %}{{ site.SEOTitle }}{% endif %}</title>
 


### PR DESCRIPTION
这样在非根路径的页面（如作品页、博客页）也能正确显示 favicon.ico

见：

- http://huangxuan.me/portfolio/
- http://huangxuan.me/2015/12/15/ios9-safari-web/

PS：

非常酷的`jekyll`，找了半天的主题，用你的了 :smile_cat: 
