### PR TITLE
Revert the revert of #40 (my fault)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,8 @@ paginate: 10
 exclude: ["less","node_modules","Gruntfile.js","package.json","README.md"]
 anchorjs: true                          # if you want to customize anchor. check out line:181 of `post.html`
 
-
+#gems
+gems: [jekyll-paginate]
 
 # Markdown settings
 # replace redcarpet to kramdown,


### PR DESCRIPTION
Reverts Huxpro/huxpro.github.io#42

Github currently unsupport `pygments` instead of `rough`. I misunderstood the "Page build warning" email and revert the #40 commit for supporting Jekyll 3.0 local preview. Now I am recovering that