### PR TITLE
MathJax Support

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -43,8 +43,8 @@
         MathJax.Hub.Config({
           jax: ["input/TeX", "output/HTML-CSS"],
           tex2jax: {
-            inlineMath: [ ['$', '$'], ["\(", "\)"] ],
-            displayMath: [ ['$$', '$$'], ["\[", "\]"] ],
+            inlineMath: [ ['$', '$']],
+            displayMath: [ ['$$', '$$']],
             processEscapes: true,
             skipTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
           }

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -39,7 +39,21 @@
         <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
         <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
-
+    <script type="text/x-mathjax-config">
+        MathJax.Hub.Config({
+          jax: ["input/TeX", "output/HTML-CSS"],
+          tex2jax: {
+            inlineMath: [ ['$', '$'], ["\(", "\)"] ],
+            displayMath: [ ['$$', '$$'], ["\[", "\]"] ],
+            processEscapes: true,
+            skipTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
+          }
+          //,
+          //displayAlign: "left",
+          //displayIndent: "2em"
+        });
+    </script>
+    <script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML" type="text/javascript"></script>
     <!-- ga & ba script hoook -->
     <script></script>
 </head>


### PR DESCRIPTION
According to [Mathjax, kramdown and Octopress](https://www.lucypark.kr/blog/2013/02/25/mathjax-kramdown-and-octopress/), add mathjax support

It seems to work well on [my page](http://airtnp.github.io/2016/05/12/test/)

Will it cause some conflict?
