### PR TITLE
Deprecate gems configuration option to use plugins

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,7 +33,7 @@ anchorjs: true                          # if you want to customize anchor. check
 
 # Gems
 # from PR#40, to support local preview for Jekyll 3.0
-gems: [jekyll-paginate]
+plugins: [jekyll-paginate]
 
 
 


### PR DESCRIPTION
In Jekyll 3.6.0, this change is to suppress the following warning:
```
Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.
```