### PR TITLE
Add Open Graph protocol support

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,6 +7,29 @@
     <meta name="keywords"  content="{{ site.keyword }}">
     <meta name="theme-color" content="{{ site.chrome-tab-theme-color }}">
     
+    <!-- Open Graph -->
+    <meta property="og:title" content="{% if page.title %}{{ page.title }} - {{ site.SEOTitle }}{% else %}{{ site.SEOTitle }}{% endif %}">
+    {% case page.layout %}
+    {% when 'post' %}
+    <meta property="og:type" content="article">
+    <meta property="og:description" content="{{ page.excerpt | strip_html | truncate:200 }}">
+    {% if page.date %}
+    <meta property="article:published_time" content="{{ page.date | date: "%Y-%m-%dT%H:%M:%SZ" }}">
+    {% endif %}
+    {% if page.author %}
+    <meta property="article:author" content="{{ page.author }}">
+    {% endif %}
+    {% for tag in page.tags %}
+    <meta property="article:tag" content="{{ tag }}">
+    {% endfor %}
+    {% else %}
+    <meta property="og:type" content="website">
+    <meta property="og:description" content="{{ site.description }}">
+    {% endcase %}
+    <meta property="og:image" content="{{ site.url }}{{ site.sidebar-avatar }}">
+    <meta property="og:url" content="{{ site.url }}{{ page.url }}">
+    <meta property="og:site_name" content="{{ site.SEOTitle }}">
+    
     <title>{% if page.title %}{{ page.title }} - {{ site.SEOTitle }}{% else %}{{ site.SEOTitle }}{% endif %}</title>
 
     <!-- Web App Manifest -->

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,7 +24,7 @@
     {% endfor %}
     {% else %}
     <meta property="og:type" content="website">
-    <meta property="og:description" content="{{ site.description }}">
+    <meta property="og:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}">
     {% endcase %}
     <meta property="og:image" content="{{ site.url }}{{ site.sidebar-avatar }}">
     <meta property="og:url" content="{{ site.url }}{{ page.url }}">


### PR DESCRIPTION
Add Open Graph protocol support
增加Open Graph协议支持

以便在社交应用中展示网页简介

### 参考：
http://ogp.me/

### 示例：
**Discord**
![discord_open_graph](https://user-images.githubusercontent.com/6592315/44882374-96a9d180-ace5-11e8-983b-2c7ffe43fb4b.png)

**Steam**
![steam_open_graph](https://user-images.githubusercontent.com/6592315/44883712-a4ae2100-acea-11e8-9980-d56e23f0ed9d.png)

**Facebook**
![facebook_open_graph](https://user-images.githubusercontent.com/6592315/44888446-d089d080-ad03-11e8-8a9b-bb2b89baa072.png)

**Skype**
![skype_open_graph](https://user-images.githubusercontent.com/6592315/44885234-48e79600-acf2-11e8-8326-6667f8b5993d.png)

🙁QQ并不支持。
如果你想要在QQ上展示网页简介，首先得是行业人士或企业，然后在[创宇信用](https://xinyong.yunaq.com)申请(~~交保护费~~)。