### PR TITLE
Fixed issue of minifying '.less' files into '.min.css'

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,7 +21,18 @@ module.exports = function(grunt) {
             minified: {
                 options: {
                     paths: ["css"],
-                    cleancss: true
+                    // Below code doesn't work from grunt-contrib-less plugin.
+                    // jaynism assume that it is a problem with less plugin's version confiction.
+                    // So jaynism removed this for fixing issue.
+                    // cleancss: true
+
+                    // But we still need minified function for '.less' files
+                    // so jaynism added below 'plugins' code instead of above 'cleancss: true' code
+                    // note: this new plugin requires specific version of dependencies such as clean-css and more.
+                    // so jaynism also updated package.json & package-lock.json files for reference. You can match your environment by typing '$npm install'.
+                    plugins: [
+                        new (require('less-plugin-clean-css'))({advanced: true})
+                    ]
                 },
                 files: {
                     "css/<%= pkg.name %>.min.css": "less/<%= pkg.name %>.less"
@@ -69,5 +80,5 @@ module.exports = function(grunt) {
 
     // Default task(s).
     grunt.registerTask('default', ['uglify', 'less', 'usebanner']);
-
+    
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,12 @@
                 "uri-js": "^4.2.2"
             }
         },
+        "amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+            "dev": true
+        },
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -188,6 +194,15 @@
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
+            }
+        },
+        "clean-css": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
+            "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
+            "dev": true,
+            "requires": {
+                "source-map": "~0.6.0"
             }
         },
         "clone": {
@@ -560,6 +575,12 @@
             "version": "4.2.4",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
             "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+            "dev": true
+        },
+        "graceful-readlink": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+            "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
             "dev": true
         },
         "grunt": {
@@ -967,6 +988,45 @@
                     "optional": true,
                     "requires": {
                         "minimist": "^1.2.5"
+                    }
+                }
+            }
+        },
+        "less-plugin-clean-css": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/less-plugin-clean-css/-/less-plugin-clean-css-1.5.1.tgz",
+            "integrity": "sha1-zFeveqM5iVflbezr5jy2DCNClwM=",
+            "dev": true,
+            "requires": {
+                "clean-css": "^3.0.1"
+            },
+            "dependencies": {
+                "clean-css": {
+                    "version": "3.4.28",
+                    "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
+                    "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
+                    "dev": true,
+                    "requires": {
+                        "commander": "2.8.x",
+                        "source-map": "0.4.x"
+                    }
+                },
+                "commander": {
+                    "version": "2.8.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                    "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-readlink": ">= 1.0.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.4.4",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                    "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                    "dev": true,
+                    "requires": {
+                        "amdefine": ">=0.0.4"
                     }
                 }
             }
@@ -1431,8 +1491,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "spdx-correct": {
             "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
         "grunt-banner": "~0.2.3",
         "grunt-contrib-less": "^2.0.0",
         "grunt-contrib-uglify": "^4.0.1",
-        "grunt-contrib-watch": "^1.1.0"
+        "grunt-contrib-watch": "^1.1.0",
+        "clean-css": "^4.2.3"
     },
     "scripts": {
         "start": "bundle exec jekyll serve -w -l --host 0.0.0.0",


### PR DESCRIPTION
There was an issue for minifying 'hux-blog.less' file into 'hux-blog.min.css'.
I assumed that 'grunt-contrib-less' plugin from Gruntfile.js doesn't work as we expected.
To be specific, "cleancss: true" from the Gruntfile.js didn't work.
So i refered the doc from the Grunt and 'less-plugin-clean-css' doc from npm. And replaced its code into new plugin option.
After replacing the code, it works as we expected. So i wanted share it for others may have same problem like me.
You can check more details from annotation i made on Gruntfile.js.