### PR TITLE
archive页面判定从title修改为单独变量

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -92,7 +92,7 @@
 {% endif %}
 
 
-{% if page.title == 'Archive' %}
+{% if page.is-archive %}
 <!-- jquery.tagcloud.js -->
 <script>
     async('{{ "/js/jquery.tagcloud.js" | prepend: site.baseurl }}', function () {

--- a/archive.html
+++ b/archive.html
@@ -3,6 +3,7 @@ title: Archive
 layout: default
 description: "「我干了什么 究竟拿了时间换了什么」"
 header-img: "img/bg-little-universe.jpg"
+is-archive: true
 ---
 
 <!--


### PR DESCRIPTION
archive页面有基于tag进行筛选的功能，这个js的生效取决于页面的title=Archive
title是用户自定义的，随时会进行修改，修改后就会导致tag筛选相关的js代码失效，采用这种自定义值作为一个feature的启用条件显然不是很合适。

这个pr做了调整，引入了新的变量，默认archive页面会通过is-archive=true来标记，从而保证相关feature的启用，并和自定义的title逻辑剥离